### PR TITLE
Export typings correctly in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,9 +31,10 @@
   "main": "./dist/automerge-patcher.umd.js",
   "module": "./dist/automerge-patcher.es.js",
   "exports": {
-     ".": {
-      "import": {"types": "./dist/types/index.d.ts",  "default": "./dist/automerge-patcher.es.js" },
-      "require": {"types": "./dist/types/index.d.ts",  "default": "./dist/automerge-patcher.umd.js"}
+    ".": {
+      "import": "./dist/automerge-patcher.es.js",
+      "require": "./dist/automerge-patcher.umd.js",
+      "types": "./dist/types/index.d.ts"
     }
   },
   "types": "./dist/types/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -31,9 +31,9 @@
   "main": "./dist/automerge-patcher.umd.js",
   "module": "./dist/automerge-patcher.es.js",
   "exports": {
-    ".": {
-      "import": "./dist/automerge-patcher.es.js",
-      "require": "./dist/automerge-patcher.umd.js"
+     ".": {
+      "import": {"types": "./dist/types/index.d.ts",  "default": "./dist/automerge-patcher.es.js" },
+      "require": {"types": "./dist/types/index.d.ts",  "default": "./dist/automerge-patcher.umd.js"}
     }
   },
   "types": "./dist/types/index.d.ts",


### PR DESCRIPTION
When using the new `"moduleResolution": "bundler"` option in TypeScript 5 I came across an error with the type definitions:

```
Could not find a declaration file for module '@onsetsoftware/automerge-patcher'. '/Users/ren/dev/crdt-test/node_modules/@onsetsoftware/automerge-patcher/dist/automerge-patcher.es.js' implicitly has an 'any' type.
  There are types at '/Users/ren/dev/crdt-test/node_modules/@onsetsoftware/automerge-patcher/dist/types/index.d.ts', but this result could not be resolved when respecting package.json "exports". The '@onsetsoftware/automerge-patcher' library may need to update its package.json or typings.ts(7016)
```

To fix this I've updated package.json to correctly link the declaration files (as seen in a similar pull request here: https://github.com/gxmari007/vite-plugin-eslint/pull/60)