### PR TITLE
Fix unpatch to handle dates

### DIFF
--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -21,8 +21,29 @@ export function isPlainObject(arg: any): arg is Record<Prop, any> {
   );
 }
 
+const replacerReviver = () => {
+  const uuid = crypto.randomUUID();
+  return [
+    function (this: Record<string, unknown>, k: string) {
+      const v: unknown = this[k];
+      if (v instanceof Date) {
+        return `${uuid}-${v.getTime()}`;
+      }
+      return v;
+    },
+    (_: string, v: unknown) => {
+      if (typeof v === "string" && v.startsWith(uuid)) {
+        return new Date(parseInt(v.slice(v.lastIndexOf("-") + 1), 10));
+      }
+      return v;
+    },
+  ];
+};
+
+const [replacer, reviver] = replacerReviver();
+
 export function clone<T>(arg: T): T {
-  return JSON.parse(JSON.stringify(arg));
+  return JSON.parse(JSON.stringify(arg, replacer), reviver);
 }
 
 export function isTextObject(arg: any): arg is Text {

--- a/tests/data.ts
+++ b/tests/data.ts
@@ -5,6 +5,7 @@ export const documentData: {
   text: Text;
   counter: Counter;
   array: string[];
+  date: Date;
   object: {
     hello: string;
     data?: string;
@@ -23,6 +24,7 @@ export const documentData: {
   };
   deeply: {
     nested: {
+      date: Date;
       object: {
         with: {
           a: {
@@ -39,6 +41,7 @@ export const documentData: {
   text: new Text("hello world"),
   counter: new Counter(0),
   array: ["hello", "world"],
+  date: new Date(1692724609057),
   object: {
     hello: "world",
     empty: "",
@@ -61,6 +64,7 @@ export const documentData: {
   },
   deeply: {
     nested: {
+      date: new Date(1692724609057),
       object: {
         with: {
           a: {

--- a/tests/unpatch.test.ts
+++ b/tests/unpatch.test.ts
@@ -60,6 +60,50 @@ describe("Un-patching patches", () => {
     },
 
     {
+      name: "put date",
+      patch: {
+        action: "put",
+        path: ["date"],
+        value: new Date(1692724758677),
+        conflict: false,
+      },
+      expected: {
+        action: "put",
+        path: ["date"],
+        value: new Date(1692724609057),
+        conflict: false,
+      },
+    },
+
+    {
+      name: "del date",
+      patch: {
+        action: "del",
+        path: ["date"],
+      },
+      expected: {
+        action: "put",
+        path: ["date"],
+        value: new Date(1692724609057),
+        conflict: false
+      },
+    },
+
+    {
+      name: "del deeply nested date",
+      patch: {
+        action: "del",
+        path: ["deeply", "nested"],
+      },
+      expected: {
+        action: "put",
+        path: ["deeply", "nested"],
+        value: documentData.deeply.nested,
+        conflict: false
+      },
+    },
+
+    {
       name: "put value where value exists",
       patch: {
         action: "put",


### PR DESCRIPTION
Running dates through JSON parse/stringify produces a string instead of a date object. Since the date objects in automerge are treated like primitives (i.e. no hidden `_context` or other fields), I think it's fine to skip the clone step.