### PR TITLE
Fix unpatch to clone non-text array items

### DIFF
--- a/src/unpatch.ts
+++ b/src/unpatch.ts
@@ -45,7 +45,7 @@ export const unpatch = <T>(doc: Doc<T>, patch: Patch): Patch => {
       path: patch.path,
       values: isTextObject(value)
         ? [...Array(length)].map((_, i) => value.get(Number(index) + i))
-        : [...Array(length)].map((_, i) => value[Number(index) + i]),
+        : [...Array(length)].map((_, i) => clone(value[Number(index) + i])),
     };
   }
 


### PR DESCRIPTION
I noticed while implementing undo/redo that array items are not cloned. This can cause automerge to fail because it doesn't want to make a reference to an existing automerge object.

<img width="508" alt="image" src="https://github.com/onsetsoftware/automerge-patcher/assets/2320890/1b7f270b-eb85-4e4b-957a-71ec6fb85967">
