### PR TITLE
Fix unpatch to support puts on Text

### DIFF
--- a/src/unpatch.ts
+++ b/src/unpatch.ts
@@ -60,6 +60,19 @@ export const unpatch = <T>(doc: Doc<T>, patch: Patch): Patch => {
         value: clone(value),
       };
     } else {
+      // getProperty cannot look up the value of text on put actions,
+      // so handle that case separately here.
+      const parent = getProperty(doc, patch.path.slice(0, -1).join("."));
+      const lastPart = patch.path[patch.path.length - 1];
+      if (isTextObject(parent) && typeof lastPart === "number") {
+        return {
+          action: "put",
+          path: patch.path,
+          conflict: false,
+          value: parent.get(lastPart)
+        }
+      }
+
       return {
         action: "del",
         path: patch.path,

--- a/tests/unpatch.test.ts
+++ b/tests/unpatch.test.ts
@@ -32,6 +32,16 @@ describe("Un-patching patches", () => {
     },
 
     {
+      name: "basic text put",
+      patch: {
+        action: "put",
+        path: ["text", 0],
+        value: "b"
+      },
+      expected: { action: "put", path: ["text", 0], value: "h", conflict: false },
+    },
+
+    {
       name: "array delete",
       patch: {
         action: "del",


### PR DESCRIPTION
Previously, put on individual characters would fail to generate a valid inverse patch. The new test case would generate a `del` patch instead of replacing the index with the old character.