### PR TITLE
Add support for unpatching deletion of byte arrays

### DIFF
--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -22,12 +22,16 @@ export function isPlainObject(arg: any): arg is Record<Prop, any> {
 
 const replacerReviver = () => {
   // we hard code a random uuid to avoid collisions
-  const uuid = "a4c5c0bf-a658-4af9-a1ad-efeb7f10c793";
+  const dateUuid = "a4c5c0bf-a658-4af9-a1ad-efeb7f10c793";
+  const bytesUuid = "7ae7efe9-84c6-4c7c-906f-0985b55c6644";
   return [
     function (this: Record<string, unknown>, k: string) {
       const v: unknown = this[k];
       if (v instanceof Date) {
-        return `${uuid}-${v.getTime()}`;
+        return `${dateUuid}-${v.getTime()}`;
+      }
+      if (isBytes(v)) {
+        return [bytesUuid, v.toString()];
       }
       if (
         typeof v === "object" &&
@@ -40,7 +44,10 @@ const replacerReviver = () => {
       return v;
     },
     (_: string, v: unknown) => {
-      if (typeof v === "string" && v.startsWith(uuid)) {
+      if (Array.isArray(v) && v[0] === bytesUuid) {
+        return new Uint8Array(v[1].split(",").map(Number));
+      }
+      if (typeof v === "string" && v.startsWith(dateUuid)) {
         return new Date(parseInt(v.slice(v.lastIndexOf("-") + 1), 10));
       }
       return v;
@@ -56,6 +63,10 @@ export function clone<T>(arg: T): T {
 
 export function isTextObject(arg: any): arg is Text {
   return arg instanceof Text;
+}
+
+export function isBytes(arg: any): arg is Uint8Array {
+  return arg instanceof Uint8Array;
 }
 
 export function getProperty<T extends Doc<T>>(

--- a/tests/data.ts
+++ b/tests/data.ts
@@ -37,6 +37,7 @@ export const documentData: {
       };
     };
   };
+  bytes: Uint8Array;
 } = {
   string: "hello world",
   text: new Text("hello world"),
@@ -78,6 +79,7 @@ export const documentData: {
       },
     },
   },
+  bytes: new Uint8Array([0, 1, 2, 3, 4, 5, 6, 7]),
 };
 
 const { text, ...withoutText } = documentData;

--- a/tests/unpatch.test.ts
+++ b/tests/unpatch.test.ts
@@ -240,6 +240,19 @@ describe("Un-patching patches", () => {
         value: "hello",
       },
     },
+    {
+      name: "delete bytes",
+      patch: {
+        action: "del",
+        path: ["bytes"],
+      },
+      expected: {
+        action: "put",
+        path: ["bytes"],
+        value: new Uint8Array([0, 1, 2, 3, 4, 5, 6, 7]),
+        conflict: false,
+      },
+    }
   ];
 
   tests.forEach(({ name, patch, expected }) => {


### PR DESCRIPTION
# Issue

Automerge supports the `Uint8Array` typed array for storing binary data in an automerge document. Automerge patcher fed this through the clone method, which caused the resulting value output to not be `new Uint8Array([0, 1, 2])` but instead an object with structure `{ 0: 0, 1: 1, 2: 2 }`, resulting in a bad unpatch.

# This Fix

This PR fixes this by updating the replacer/reviver function used in unpatch, to mark any `Uint8Array`'s by replacing it by `[hardcodedUuid, bytes.toString()]`. The reviver then checks the hardcoded UUID, and created a new `Uint8Array` from the stringified data. This is similar to how the unpatch method currently handles the `Date` type.

Maybe there's a better way of cloning the `Uint8Array` rather than replacing/reviving it, but tried to follow current patterns as much as possible. Feel free to provide any feedback on better way's to handle this type!